### PR TITLE
Task 3: First API with AWS API Gateway and AWS Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
-# Welcome to your CDK TypeScript project
+# AWS Back Project
 
-This is a blank project for CDK development with TypeScript.
+This repository contains the backend microservices for the project. The backend is implemented using AWS CDK, AWS Lambda, and AWS API Gateway. It includes the following services:
 
-The `cdk.json` file tells the CDK Toolkit how to execute your app.
+- **Product Service**: Manages product-related endpoints.
+- **Import Service**: (If applicable) Handles the importing of product data.
+- **Authorization Service**: (If applicable) Manages user authentication and authorization.
 
-## Useful commands
+---
 
-* `npm run build`   compile typescript to js
-* `npm run watch`   watch for changes and compile
-* `npm run test`    perform the jest unit tests
-* `npx cdk deploy`  deploy this stack to your default AWS account/region
-* `npx cdk diff`    compare deployed stack with current state
-* `npx cdk synth`   emits the synthesized CloudFormation template
+## Project Structure
+
+```plaintext
+aws-back/
+├── authorization_service   # Authentication/authorization microservice repository
+├── import_service          # Service for importing product data
+├── product_service         # Service for product data management
+│   ├── src/                # Source code for Lambda functions
+│   ├── __test__/           # Unit tests for Lambda functions
+│   ├── openapi.yaml        # Swagger documentation for Product Service
+│   └── cdk/                # AWS CDK configuration and stack definitions
+├── package.json            # Project-level configuration
+└── README.md               # This documentation file
+```

--- a/services/product-service/getProductsById.ts
+++ b/services/product-service/getProductsById.ts
@@ -1,12 +1,8 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
+import { products } from './mock-data';
 
 export const handler: APIGatewayProxyHandler = async (event) => {
   const { productId } = event.pathParameters || {};
-
-  const products = [
-    { id: '1', name: 'ProductA', price: 100 },
-    { id: '2', name: 'ProductB', price: 200 },
-  ];
 
   const product = products.find((p) => p.id === productId);
 

--- a/services/product-service/getProductsList.ts
+++ b/services/product-service/getProductsList.ts
@@ -1,12 +1,7 @@
 import { APIGatewayProxyHandler } from 'aws-lambda';
+import { products } from './mock-data';
 
 export const handler: APIGatewayProxyHandler = async () => {
-  const products = [
-    { id: '1', title: 'ProductA', description:'This is product A description', price: 100 },
-    { id: '2', title: 'ProductB',description:'This is product B description', price: 200 },
-    { id: '3', title: 'ProductC',description:'This is product C description', price: 300 },
-  ];
-
   return {
     statusCode: 200,
     headers: {

--- a/services/product-service/mock-data.ts
+++ b/services/product-service/mock-data.ts
@@ -1,0 +1,5 @@
+export const products = [
+  { id: '1', title: 'ProductA', description: 'This is product A description', price: 100 },
+  { id: '2', title: 'ProductB', description: 'This is product B description', price: 200 },
+  { id: '3', title: 'ProductC', description: 'This is product C description', price: 300 },
+];


### PR DESCRIPTION
# Task 3: First API with AWS API Gateway and AWS Lambda

## What was done

1. **Lambda `getProductsList`**  
   - Created and deployed an AWS Lambda function that returns a list of mock products.  
   - Configured an HTTP GET endpoint at `/products` via API Gateway.

2. **Lambda `getProductsById`**  
   - Created and deployed an AWS Lambda function that returns a single product by `productId`.  
   - Configured an HTTP GET endpoint at `/products/{productId}` via API Gateway.

3. **Integration with Frontend**  
   - Updated frontend to fetch products from the `/products` endpoint.  
   - Products are now displayed on the Product List Page (PLP).

4. **Swagger Documentation**  
   - Added a minimal `openapi.yaml` file in the service folder documenting both endpoints.  
   - Includes the `Product` schema definition.

5. **Unit Tests (Additional Scope)**  
   - Implemented basic unit tests for both Lambdas using Jest.  
   - Ensured `getProductsList` and `getProductsById` handlers return expected status codes and response bodies.

## Links

- **Product Service API**: [https://qeonfvidg3.execute-api.eu-central-1.amazonaws.com/prod](#)  
  - Endpoints:
    - `/products`  
    - `/products/{productId}`  

- **Frontend Repository**: [Frontend Repo PR Link](https://github.com/natenadze1102/aws-front)

- **Product List Page (PLP) (Cloudflare link)**: [View Product List Page](https://dity7u4qnav41.cloudfront.net/)

## Product Schema

In case the Swagger file is not accessible, here is a basic schema example:

```json
{
  "id": "string",
  "title": "string",
  "description": "string",
  "price": "number"
}